### PR TITLE
feat: add monospace font 'Courier New' to calc package

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Arguments:
   file                          *.ttf, *.otf, *.woff or *.woff2 font file
 
 Options:
-  -f, --fallback <font-family>  fallback font family type: "serif" or "sans-serif" (default: "serif")
+  -f, --fallback <font-family>  fallback font family type: "serif", "sans-serif" or "mono" (default: "san-serif")
   -s, --style <style>           font-style value (default: "normal")
   -w, --weight <weight>         font-weight value (default: "400")
   -n, --name <name>             font name what will be used as font-family value, by default font filename

--- a/packages/calc/util.js
+++ b/packages/calc/util.js
@@ -10,7 +10,7 @@ const DefaultFont = {
       azAvgWidth: 907.5581395348837,
       unitsPerEm: 2048
     },
-    ITALIC: {
+    REGULAR_ITALIC: {
       name: 'Times New Roman Italic',
       azAvgWidth: 846.5581395348837,
       unitsPerEm: 2048
@@ -32,7 +32,7 @@ const DefaultFont = {
       azAvgWidth: 1011.046511627907,
       unitsPerEm: 2048
     },
-    ITALIC: {
+    REGULAR_ITALIC: {
       name: 'Arial Italic',
       azAvgWidth: 934.5116279069767,
       unitsPerEm: 2048
@@ -54,7 +54,7 @@ const DefaultFont = {
       azAvgWidth: 1229,
       unitsPerEm: 2048
     },
-    ITALIC: {
+    REGULAR_ITALIC: {
       name: 'Courier New Italic',
       azAvgWidth: 1229,
       unitsPerEm: 2048

--- a/packages/calc/util.js
+++ b/packages/calc/util.js
@@ -42,11 +42,33 @@ const DefaultFont = {
       azAvgWidth: 1011.046511627907,
       unitsPerEm: 2048
     }
+  },
+  MONO: {
+    REGULAR: {
+      name: 'Courier New',
+      azAvgWidth: 1229,
+      unitsPerEm: 2048
+    },
+    BOLD: {
+      name: 'Courier New Bold',
+      azAvgWidth: 1229,
+      unitsPerEm: 2048
+    },
+    ITALIC: {
+      name: 'Courier New Italic',
+      azAvgWidth: 1229,
+      unitsPerEm: 2048
+    },
+    BOLD_ITALIC: {
+      name: 'Courier New Bold Italic',
+      azAvgWidth: 1229,
+      unitsPerEm: 2048
+    }
   }
 }
 
 const getFallbackFont = (family, weight, style) => {
-  const _family = family === 'serif' ? 'SERIF' : 'SANS_SERIF'
+  const _family = family === 'serif' ? 'SERIF' : family === 'mono' ? 'MONO' : 'SANS_SERIF'
   const _weight = weight === 'bold' || weight > 500 ? 'BOLD' : 'REGULAR'
   const _style = style === 'italic' ? '_ITALIC' : ''
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,7 +72,7 @@ Arguments:
   file                          *.ttf, *.otf, *.woff or *.woff2 font file
 
 Options:
-  -f, --fallback <font-family>  fallback font family type: "serif" or "sans-serif" (default: "san-serif")
+  -f, --fallback <font-family>  fallback font family type: "serif", "sans-serif" or "mono" (default: "san-serif")
   -s, --style <style>           font-style value (default: "normal")
   -w, --weight <weight>         font-weight value (default: "400")
   -n, --name <name>             font name what will be used as font-family value, by default font filename

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,7 +72,7 @@ Arguments:
   file                          *.ttf, *.otf, *.woff or *.woff2 font file
 
 Options:
-  -f, --fallback <font-family>  fallback font family type: "serif" or "sans-serif" (default: "serif")
+  -f, --fallback <font-family>  fallback font family type: "serif" or "sans-serif" (default: "san-serif")
   -s, --style <style>           font-style value (default: "normal")
   -w, --weight <weight>         font-weight value (default: "400")
   -n, --name <name>             font name what will be used as font-family value, by default font filename


### PR DESCRIPTION
This pull request adds:
-  monospace font 'Courier New' to calc package;
-  small fix in readme;

**Checklist**:
- [x] Сhecked for linter errors;
